### PR TITLE
Improve message handling in RosTopicSubNode with 50ms timeout wait

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -338,10 +338,15 @@ void RosTopicSubNode<T>::spinUntilMessageAvailable()
     auto start_time = std::chrono::steady_clock::now();
     const auto timeout = std::chrono::milliseconds(50);
     
-    while (!last_msg_ && (std::chrono::steady_clock::now() - start_time) < timeout) 
+    auto should_continue_spin = [this](const auto& start_time, const auto& timeout) {
+      return !last_msg_ && (std::chrono::steady_clock::now() - start_time) < timeout;
+    };
+
+    while (should_continue_spin(start_time, timeout)) 
     {
       spin_some();
-      if (!last_msg_) {
+      if (!last_msg_) 
+      {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
     }

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -314,7 +314,24 @@ inline NodeStatus RosTopicSubNode<T>::tick()
     }
     return status;
   };
-  sub_instance_->callback_group_executor.spin_some();
+  // Spin with timeout until message is available
+  if (!last_msg_) 
+  {
+    auto start_time = std::chrono::steady_clock::now();
+    const auto timeout = std::chrono::milliseconds(50); // 50ms timeout
+    
+    while (!last_msg_ && (std::chrono::steady_clock::now() - start_time) < timeout) 
+    {
+      sub_instance_->callback_group_executor.spin_some();
+      if (!last_msg_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+    }
+  } 
+  else 
+  {
+    sub_instance_->callback_group_executor.spin_some();
+  }
   auto status = CheckStatus(onTick(last_msg_));
   if(!latchLastMessage())
   {

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 #include <string>
+#include <chrono>
+#include <thread>
 #include <rclcpp/executors.hpp>
 #include <rclcpp/allocator/allocator_common.hpp>
 #include "behaviortree_cpp/condition_node.h"
@@ -157,6 +159,7 @@ public:
 
 private:
   bool createSubscriber(const std::string& topic_name);
+  void spinUntilMessageAvailable();
 };
 
 //----------------------------------------------------------------
@@ -314,15 +317,30 @@ inline NodeStatus RosTopicSubNode<T>::tick()
     }
     return status;
   };
-  // Spin with timeout until message is available
+  this->spinUntilMessageAvailable();
+  auto status = CheckStatus(onTick(last_msg_));
+  if(!latchLastMessage())
+  {
+    last_msg_.reset();
+  }
+  return status;
+}
+
+template <class T>
+void RosTopicSubNode<T>::spinUntilMessageAvailable()
+{
+  auto spin_some = [this]() {
+    sub_instance_->callback_group_executor.spin_some();
+  };
+
   if (!last_msg_) 
   {
     auto start_time = std::chrono::steady_clock::now();
-    const auto timeout = std::chrono::milliseconds(50); // 50ms timeout
+    const auto timeout = std::chrono::milliseconds(50);
     
     while (!last_msg_ && (std::chrono::steady_clock::now() - start_time) < timeout) 
     {
-      sub_instance_->callback_group_executor.spin_some();
+      spin_some();
       if (!last_msg_) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
@@ -330,14 +348,8 @@ inline NodeStatus RosTopicSubNode<T>::tick()
   } 
   else 
   {
-    sub_instance_->callback_group_executor.spin_some();
+    spin_some();
   }
-  auto status = CheckStatus(onTick(last_msg_));
-  if(!latchLastMessage())
-  {
-    last_msg_.reset();
-  }
-  return status;
 }
 
 }  // namespace BT


### PR DESCRIPTION
This pull request introduces a mechanism to ensure that the `RosTopicSubNode<T>::tick()` method waits briefly for a message to arrive before proceeding, improving reliability in cases where messages may not be immediately available.

**Message handling improvements:**

* Added a 50ms timeout-based spinning loop to wait for a message (`last_msg_`) before proceeding, allowing the node to handle cases where the message hasn't arrived yet. (`behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp`, [behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hppR317-R334](diffhunk://#diff-922885f7d3aa9db20a91364ba426408b8b27aa2b8ce27c4d40b618961b2a8b81R317-R334))
* The method now sleeps for 1ms intervals during the wait, reducing CPU usage while polling for the message. (`behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp`, [behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hppR317-R334](diffhunk://#diff-922885f7d3aa9db20a91364ba426408b8b27aa2b8ce27c4d40b618961b2a8b81R317-R334))