### PR TITLE
Refactor `spinUntilMessageAvailable` for improved message waiting logic and timeout handling

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -329,31 +329,26 @@ inline NodeStatus RosTopicSubNode<T>::tick()
 template <class T>
 void RosTopicSubNode<T>::spinUntilMessageAvailable()
 {
-  auto spin_some = [this]() {
+  auto spin_some = [this]()
+  {
     sub_instance_->callback_group_executor.spin_some();
   };
 
-  if (!last_msg_) 
-  {
-    auto start_time = std::chrono::steady_clock::now();
-    const auto timeout = std::chrono::milliseconds(50);
-    
-    auto should_continue_spin = [this](const auto& start_time, const auto& timeout) {
-      return !last_msg_ && (std::chrono::steady_clock::now() - start_time) < timeout;
-    };
+  auto start_time = std::chrono::steady_clock::now();
+  const auto timeout = std::chrono::milliseconds(1000);
+  std::shared_ptr<T> previous_msg = last_msg_;
 
-    while (should_continue_spin(start_time, timeout)) 
-    {
-      spin_some();
-      if (!last_msg_) 
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      }
-    }
-  } 
-  else 
+  auto should_continue_spin = [this, &previous_msg](const auto& start_time, const auto& timeout) 
+  {
+    bool has_new_message = last_msg_ && (last_msg_ != previous_msg);
+    bool within_timeout = (std::chrono::steady_clock::now() - start_time) < timeout;
+    return !has_new_message && within_timeout;
+  };
+
+  while (should_continue_spin(start_time, timeout))
   {
     spin_some();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
 


### PR DESCRIPTION
This pull request refactors the `spinUntilMessageAvailable` method in `bt_topic_sub_node.hpp` to improve message waiting logic and timeout handling. The updated implementation ensures that the node waits for a new message for up to 1000 milliseconds, rather than just checking for any message, and removes unnecessary branching for cleaner code.

Message waiting and timeout logic improvements:
* Increased the message waiting timeout from 50ms to 1000ms for better responsiveness.
* Changed the condition to wait specifically for a new message (by comparing `last_msg_` to the previous message), rather than just the presence of any message.

Code simplification:
* Removed unnecessary `if`/`else` branching, making the method more concise and easier to maintain.