### PR TITLE
Prevent Duplicate Callback Group Management in Behavior Tree ROS2 Nodes

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
@@ -180,6 +180,7 @@ protected:
     rclcpp::CallbackGroup::SharedPtr callback_group;
     rclcpp::executors::SingleThreadedExecutor callback_executor;
     typename ActionClient::SendGoalOptions goal_options;
+    bool use_internal_executor = false; // Flag to indicate if internal executor is active
   };
 
   static std::mutex& getMutex()
@@ -243,10 +244,21 @@ template <class T>
 RosActionNode<T>::ActionClientInstance::ActionClientInstance(
     std::shared_ptr<rclcpp::Node> node, const std::string& action_name)
 {
+  RCLCPP_DEBUG(node->get_logger(), "Creating callback group for action: %s", action_name.c_str());
   callback_group =
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
+  // Try to add callback group to internal executor, but handle gracefully if already managed
+  try {
+    callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
+    use_internal_executor = true;
+    RCLCPP_DEBUG(node->get_logger(), "Added callback group to internal executor for action: %s", action_name.c_str());
+  } catch (const std::runtime_error& e) {
+    // This is expected when the node is already managed by an external executor
+    use_internal_executor = false;
+    RCLCPP_DEBUG(node->get_logger(), "Callback group already managed externally for action: %s - %s", action_name.c_str(), e.what());
+  }
   action_client = rclcpp_action::create_client<T>(node, action_name, callback_group);
+  RCLCPP_DEBUG(node->get_logger(), "Created action client for: %s", action_name.c_str());
 }
 
 template <class T>
@@ -444,7 +456,10 @@ inline NodeStatus RosActionNode<T>::tick()
   if(status() == NodeStatus::RUNNING)
   {
     std::unique_lock<std::mutex> lock(getMutex());
-    client_instance_->callback_executor.spin_some();
+    if(client_instance_->use_internal_executor)
+    {
+      client_instance_->callback_executor.spin_some();
+    }
 
     // FIRST case: check if the goal request has a timeout
     if(!goal_received_)
@@ -453,8 +468,21 @@ inline NodeStatus RosActionNode<T>::tick()
       auto timeout =
           rclcpp::Duration::from_seconds(double(server_timeout_.count()) / 1000);
 
-      auto ret = client_instance_->callback_executor.spin_until_future_complete(
-          future_goal_handle_, nodelay);
+      rclcpp::FutureReturnCode ret;
+      if(client_instance_->use_internal_executor)
+      {
+        ret = client_instance_->callback_executor.spin_until_future_complete(
+            future_goal_handle_, nodelay);
+      }
+      else
+      {
+        // When external executor is managing callbacks, just check future status
+        auto status = future_goal_handle_.wait_for(nodelay);
+        ret = (status == std::future_status::ready) ?
+              rclcpp::FutureReturnCode::SUCCESS :
+              rclcpp::FutureReturnCode::TIMEOUT;
+      }
+      
       if(ret != rclcpp::FutureReturnCode::SUCCESS)
       {
         if((now() - time_goal_sent_) > timeout)

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
@@ -148,6 +148,7 @@ protected:
     ServiceClientPtr service_client;
     rclcpp::CallbackGroup::SharedPtr callback_group;
     rclcpp::executors::SingleThreadedExecutor callback_executor;
+    bool use_internal_executor = false; // Flag to indicate if internal executor is active
   };
 
   static std::mutex& getMutex()
@@ -212,12 +213,24 @@ template <class T>
 inline RosServiceNode<T>::ServiceClientInstance::ServiceClientInstance(
     std::shared_ptr<rclcpp::Node> node, const std::string& service_name)
 {
+  RCLCPP_DEBUG(node->get_logger(), "Creating callback group for service: %s", service_name.c_str());
   callback_group =
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
-  callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
+
+  // Try to add callback group to internal executor, but handle gracefully if already managed
+  try {
+    callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
+    use_internal_executor = true;
+    RCLCPP_DEBUG(node->get_logger(), "Added callback group to internal executor for service: %s", service_name.c_str());
+  } catch (const std::runtime_error& e) {
+    // This is expected when the node is already managed by an external executor
+    use_internal_executor = false;
+    RCLCPP_DEBUG(node->get_logger(), "Callback group already managed externally for service: %s - %s", service_name.c_str(), e.what());
+  }
 
   service_client = node->create_client<T>(service_name, rmw_qos_profile_services_default,
                                           callback_group);
+  RCLCPP_DEBUG(node->get_logger(), "Created service client for: %s", service_name.c_str());
 }
 
 template <class T>
@@ -370,7 +383,10 @@ inline NodeStatus RosServiceNode<T>::tick()
 
   if(status() == NodeStatus::RUNNING)
   {
-    srv_instance_->callback_executor.spin_some();
+    if(srv_instance_->use_internal_executor)
+    {
+      srv_instance_->callback_executor.spin_some();
+    }
 
     // FIRST case: check if the goal request has a timeout
     if(!response_received_)
@@ -379,8 +395,20 @@ inline NodeStatus RosServiceNode<T>::tick()
       auto const timeout =
           rclcpp::Duration::from_seconds(double(service_timeout_.count()) / 1000);
 
-      auto ret = srv_instance_->callback_executor.spin_until_future_complete(
-          future_response_, nodelay);
+      rclcpp::FutureReturnCode ret;
+      if(srv_instance_->use_internal_executor)
+      {
+        ret = srv_instance_->callback_executor.spin_until_future_complete(
+            future_response_, nodelay);
+      }
+      else
+      {
+        // When external executor is managing callbacks, just check future status
+        auto status = future_response_.wait_for(nodelay);
+        ret = (status == std::future_status::ready) ?
+              rclcpp::FutureReturnCode::SUCCESS :
+              rclcpp::FutureReturnCode::TIMEOUT;
+      }
 
       if(ret != rclcpp::FutureReturnCode::SUCCESS)
       {

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -60,6 +60,7 @@ protected:
     rclcpp::executors::SingleThreadedExecutor callback_group_executor;
     boost::signals2::signal<void(const std::shared_ptr<TopicT>)> broadcaster;
     std::shared_ptr<TopicT> last_msg;
+    bool use_internal_executor = false; // Flag to indicate if internal executor is active
   };
 
   static std::mutex& registryMutex()
@@ -169,11 +170,21 @@ template <class T>
 inline RosTopicSubNode<T>::SubscriberInstance::SubscriberInstance(
     std::shared_ptr<rclcpp::Node> node, const std::string& topic_name)
 {
+  RCLCPP_DEBUG(node->get_logger(), "Creating callback group for topic: %s", topic_name.c_str());
   // create a callback group for this particular instance
   callback_group =
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
-  callback_group_executor.add_callback_group(callback_group,
-                                             node->get_node_base_interface());
+  // Try to add callback group to internal executor, but handle gracefully if already managed
+  try {
+    callback_group_executor.add_callback_group(callback_group,
+                                               node->get_node_base_interface());
+    use_internal_executor = true;
+    RCLCPP_DEBUG(node->get_logger(), "Added callback group to internal executor for topic: %s", topic_name.c_str());
+  } catch (const std::runtime_error& e) {
+    // This is expected when the node is already managed by an external executor
+    use_internal_executor = false;
+    RCLCPP_DEBUG(node->get_logger(), "Callback group already managed externally for topic: %s - %s", topic_name.c_str(), e.what());
+  }
 
   rclcpp::SubscriptionOptions option;
   option.callback_group = callback_group;
@@ -331,7 +342,10 @@ void RosTopicSubNode<T>::spinUntilMessageAvailable()
 {
   auto spin_some = [this]()
   {
-    sub_instance_->callback_group_executor.spin_some();
+    if(sub_instance_->use_internal_executor)
+    {
+      sub_instance_->callback_group_executor.spin_some();
+    }
   };
 
   auto start_time = std::chrono::steady_clock::now();


### PR DESCRIPTION
This pull request improves how ROS2 behavior tree nodes (action, service, and topic subscription nodes) manage their callback groups and executors. The main enhancement is that these nodes now handle cases where their callback groups may already be managed by an external executor, ensuring more robust and flexible integration in complex ROS2 systems. Debug logging is also added for better traceability.

Callback group and executor management:

* Added a `use_internal_executor` flag to `ActionClientInstance`, `ServiceClientInstance`, and `SubscriberInstance` classes to track whether the internal executor is managing the callback group. This prevents duplicate management and potential runtime errors. [[1]](diffhunk://#diff-ee2ed71e8f92868ebe11f7aa6cb622ebed92dc3bb4998cbf1a7923540cbc8759R183) [[2]](diffhunk://#diff-927853c1c86cd6a333e6788354257ea4650618495f2ec3046e9c1991cfadf4a4R151) [[3]](diffhunk://#diff-922885f7d3aa9db20a91364ba426408b8b27aa2b8ce27c4d40b618961b2a8b81R63)
* Updated constructors for these instances to attempt adding their callback group to the internal executor, but gracefully handle the case where the group is already managed externally. Detailed debug logs are provided for both success and failure scenarios. [[1]](diffhunk://#diff-ee2ed71e8f92868ebe11f7aa6cb622ebed92dc3bb4998cbf1a7923540cbc8759R247-R261) [[2]](diffhunk://#diff-927853c1c86cd6a333e6788354257ea4650618495f2ec3046e9c1991cfadf4a4R216-R233) [[3]](diffhunk://#diff-922885f7d3aa9db20a91364ba426408b8b27aa2b8ce27c4d40b618961b2a8b81R173-R187)

Tick and spinning logic:

* Modified the `tick()` methods and spinning functions to check the `use_internal_executor` flag. If true, the internal executor spins or waits for futures; if false, status is checked directly, avoiding unnecessary spinning and respecting external executor management. [[1]](diffhunk://#diff-ee2ed71e8f92868ebe11f7aa6cb622ebed92dc3bb4998cbf1a7923540cbc8759R459-R462) [[2]](diffhunk://#diff-ee2ed71e8f92868ebe11f7aa6cb622ebed92dc3bb4998cbf1a7923540cbc8759L456-R485) [[3]](diffhunk://#diff-927853c1c86cd6a333e6788354257ea4650618495f2ec3046e9c1991cfadf4a4R385-R389) [[4]](diffhunk://#diff-927853c1c86cd6a333e6788354257ea4650618495f2ec3046e9c1991cfadf4a4L382-R411) [[5]](diffhunk://#diff-922885f7d3aa9db20a91364ba426408b8b27aa2b8ce27c4d40b618961b2a8b81L332-R348)