### PR TITLE
Expose private members as protected in BehaviorTree.ROS2 node classes

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
@@ -224,7 +224,6 @@ protected:
   const std::chrono::milliseconds wait_for_server_timeout_;
   std::string action_client_key_;
 
-private:
   std::shared_future<typename GoalHandle::SharedPtr> future_goal_handle_;
   typename GoalHandle::SharedPtr goal_handle_;
 

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
@@ -193,7 +193,6 @@ protected:
   const std::chrono::milliseconds service_timeout_;
   const std::chrono::milliseconds wait_for_service_timeout_;
 
-private:
   std::shared_ptr<ServiceClientInstance> srv_instance_;
   std::shared_future<typename Response::SharedPtr> future_response_;
 

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_pub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_pub_node.hpp
@@ -89,7 +89,6 @@ protected:
   std::string prev_topic_name_;
   bool topic_name_may_change_ = false;
 
-private:
   std::shared_ptr<Publisher> publisher_;
 
   bool createPublisher(const std::string& topic_name);

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_pub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_pub_node.hpp
@@ -72,7 +72,7 @@ public:
     return providedBasicPorts({});
   }
 
-  NodeStatus tick() override final;
+  NodeStatus tick() override;
 
   /**
    * @brief setMessage is a callback invoked in tick to allow the user to pass

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -134,7 +134,7 @@ public:
     return providedBasicPorts({});
   }
 
-  NodeStatus tick() override final;
+  NodeStatus tick() override;
 
   /** Callback invoked in the tick. You must return either SUCCESS of FAILURE
    *

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -158,7 +158,6 @@ public:
     return false;
   }
 
-private:
   bool createSubscriber(const std::string& topic_name);
   void spinUntilMessageAvailable();
 };

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -158,6 +158,7 @@ public:
     return false;
   }
 
+protected:
   bool createSubscriber(const std::string& topic_name);
   void spinUntilMessageAvailable();
 };


### PR DESCRIPTION
This pull request makes a small but important change to the visibility of several member variables in the behavior tree ROS2 node classes. Specifically, it moves previously private members to protected sections, making them accessible to derived classes and potentially improving extensibility for custom node implementations.

Access control modifications for extensibility:

* [`behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp`](diffhunk://#diff-ee2ed71e8f92868ebe11f7aa6cb622ebed92dc3bb4998cbf1a7923540cbc8759L227): Moved `future_goal_handle_` and `goal_handle_` from private to protected in `RosActionNode`, allowing derived classes to access these members.
* [`behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp`](diffhunk://#diff-927853c1c86cd6a333e6788354257ea4650618495f2ec3046e9c1991cfadf4a4L196): Moved `srv_instance_` and `future_response_` from private to protected in `RosServiceNode`, enabling easier subclassing and custom logic.
* [`behaviortree_ros2/include/behaviortree_ros2/bt_topic_pub_node.hpp`](diffhunk://#diff-e1f3f4000c004cf5c1b7f1eba69a6b1d88d1383a5092013d17bb120126927a20L92): Changed `publisher_` from private to protected in `RosTopicPubNode`, facilitating direct access in subclasses.
* [`behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp`](diffhunk://#diff-922885f7d3aa9db20a91364ba426408b8b27aa2b8ce27c4d40b618961b2a8b81L161): Moved `createSubscriber` and `spinUntilMessageAvailable` methods from private to protected in `RosTopicSubNode`, allowing overriding and reuse in derived classes.